### PR TITLE
Add PyVista to the SciVis list

### DIFF
--- a/doc/scivis/index.md
+++ b/doc/scivis/index.md
@@ -18,4 +18,4 @@ SciVis libraries supporting Python:
 
 - [yt](https://yt-project.org) is a package for analyzing and visualizing volumetric data. yt supports structured, variable-resolution meshes, unstructured meshes, and discrete or sampled data such as particles.
 
-- [PyVista](http://www.pyvista.org) is a streamlined interface for the Visualization Toolkit (VTK) providing 3D plotting and mesh analysis with NumPy support being at it's core. PyVista is a Pythonic, well-documented API exposing VTK’s powerful visualization backend facilitating rapid prototyping, analysis, and visual integration of spatially referenced datasets.
+- [PyVista](http://www.pyvista.org) is a streamlined interface for the Visualization Toolkit (VTK) providing 3D plotting and mesh analysis with NumPy support being at its core. PyVista supports point clouds, structured/unstructured meshes, and volumetric datasets.

--- a/doc/scivis/index.md
+++ b/doc/scivis/index.md
@@ -17,3 +17,5 @@ SciVis libraries supporting Python:
 - [ParaView](https://www.paraview.org) (from [Kitware](https://www.kitware.com/)) allows users to quickly build visualizations to analyze their data using qualitative and quantitative techniques. The data exploration can be done interactively in 3D or programmatically using batch processing capabilities.
 
 - [yt](https://yt-project.org) is a package for analyzing and visualizing volumetric data. yt supports structured, variable-resolution meshes, unstructured meshes, and discrete or sampled data such as particles.
+
+- [PyVista](http://www.pyvista.org) is a streamlined interface for the Visualization Toolkit (VTK) providing 3D plotting and mesh analysis with NumPy support being at it's core. PyVista is a Pythonic, well-documented API exposing VTK’s powerful visualization backend facilitating rapid prototyping, analysis, and visual integration of spatially referenced datasets.

--- a/doc/scivis/index.rst
+++ b/doc/scivis/index.rst
@@ -12,3 +12,4 @@
    Mayavi <https://docs.enthought.com/mayavi/mayavi>
    ParaView <https://www.paraview.org>
    yt <https://yt-project.org>
+   PyVista <http://www.pyvista.org>


### PR DESCRIPTION
I propose adding [PyVista](https://github.com/pyvista/pyvista) to the SciViz list. I see that VTK is already on there... PyVista provides a Pythonic interface to VTK, breaking down the barrier to entry for access to a powerful 3D viz toolset.