### PR TITLE
Add ArviZ to "other domain specific"

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -227,6 +227,11 @@
     - repo: ismms-himc/clustergrammer2
       site: https://clustergrammer.readthedocs.io/
       badges: pypi, site      
+      
+    - repo: arviz-devs/arviz
+      site: https://arviz-devs.github.io/arviz/
+      conda_channel: conda-forge
+      badges: pypi, travis, azure, coveralls, conda, site      
 
 - name: Large-data rendering
   intro: Tools for server-side rasterizing/aggregating data before visualization.

--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -229,6 +229,7 @@
       badges: pypi, site      
       
     - repo: arviz-devs/arviz
+      sponsors: [numfocus]
       site: https://arviz-devs.github.io/arviz/
       conda_channel: conda-forge
       badges: pypi, travis, azure, coveralls, conda, site      


### PR DESCRIPTION
ArviZ supports visualizations for probabilistic programming libraries like `stan`, `pymc3`, `pyro`, `emcee`, or `tensorflow-probability`. See https://arviz-devs.github.io/arviz for more details.

I did my best on the changes -- thank you for the site!