### PR TITLE
Update Yellowbrick tools

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -216,7 +216,8 @@
 
     - repo: DistrictDataLabs/yellowbrick
       site: https://www.scikit-yb.org
-      badges: pypi, site
+      conda_channel: DistrictDataLabs
+      badges: travis, appveyor, pypi, conda, site
 
     - repo: yt-project/yt
       sponsors: [numfocus]

--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -215,7 +215,8 @@
       conda_channel: conda-forge
 
     - repo: DistrictDataLabs/yellowbrick
-      site: https://www.scikit-yb.org
+       site: https://www.scikit-yb.org
+       sponsors: [numfocus]
       conda_channel: DistrictDataLabs
       badges: travis, appveyor, pypi, conda, site
 


### PR DESCRIPTION
Added Yellowbrick's conda channel and CI badges. 

Quick question: Yellowbrick is an [affiliated NumFOCUS project](https://numfocus.org/sponsored-projects/affiliated-projects) - may we add NumFOCUS to the sponsor's list?