### PR TITLE
Split caching into different jobs and store cache output in branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,14 @@ jobs:
     - &website_release
       <<: *test
       stage: website_release
-      script: doit build_website
+      env: BUILD_CACHE=True
+      script:
+        # these steps can be called using doit build_website, but the Travis job will time out
+        - python tools/conda_downloads.py
+        - python tools/build.py
+        - mv tools/index.rst doc/tools.rst
+        - nbsite generate-rst --org pyviz --project-name pyviz --examples notebooks
+        - nbsite build --what=html --output=builtdocs
       deploy:
         - provider: pages
           skip_cleanup: true
@@ -56,4 +63,3 @@ jobs:
           repo: pyviz-dev/website
           on:
             all_branches: true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,9 @@ jobs:
 
     - <<: *build_cache
       env: BADGE=conda_downloads
-      script: python tools/conda_downloads.py
+      script:
+        - conda install -c conda-forge colorcet fastparquet intake intake-parquet s3fs
+        - python tools/conda_downloads.py
 
     - &website_release
       <<: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,22 @@ jobs:
       stage: website_release
       env: BUILD_CACHE=True
       script:
-        # these steps can be called using doit build_website, but the Travis job will time out
+        # these steps can be called using doit build_cache
+        # but the Travis job will time out, so they are split up here
         - python tools/conda_downloads.py
-        - python tools/build.py
-        - mv tools/index.rst doc/tools.rst
-        - nbsite generate-rst --org pyviz --project-name pyviz --examples notebooks
-        - nbsite build --what=html --output=builtdocs
+        - SECTION="Core" python tools/build_cache.py
+        - SECTION="High-Level Shared API" python tools/build_cache.py
+        - SECTION="High-Level" python tools/build_cache.py
+        - SECTION="Native-GUI" python tools/build_cache.py
+        - SECTION="Other InfoVis" python tools/build_cache.py
+        - SECTION="SciVis" python tools/build_cache.py
+        - SECTION="Geospatial" python tools/build_cache.py
+        - SECTION="Other domain-specific" python tools/build_cache.py
+        - SECTION="Large-data rendering" python tools/build_cache.py
+        - SECTION="Dashboarding" python tools/build_cache.py
+        - SECTION="Colormapping" python tools/build_cache.py
+        - SECTION="Dormant projects" python tools/build_cache.py
+        - doit build_website
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ jobs:
 
     - <<: *website_release
       stage: website_dev
-      script: doit build_website
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,10 @@ jobs:
     - &website_release
       <<: *test
       stage: website_release
+      before_script:
+        - git checkout -b deploy-${TRAVIS_BRANCH}
+        - git fetch https://github.com/$TRAVIS_REPO_SLUG.git cache:refs/remotes/cache  # all cached badges are in this branc
+        - git checkout cache -- ./doc/_static/cache
       script: doit build_website
       deploy:
         - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
 
 stages:
   - test
+  - name: build_cache
+    if: (commit_message =~ /^.*(website_dev).*$/) OR (branch = master)
   - name: website_release
     if: branch = master
   - name: website_dev
@@ -32,27 +34,39 @@ jobs:
           fi;
         - doit test_all
 
+    - &build_cache
+      <<: *test
+      stage: build_cache
+      env: BADGE=pypi_downloads
+      script: python tools/build_cache.py
+      after_success:
+        - git config user.email "travis@travis.org"
+        - git config user.name "travis"
+        - mv ./doc/_static/cache ./tmp
+        - git fetch https://github.com/$TRAVIS_REPO_SLUG.git cache:refs/remotes/cache
+        - git checkout cache
+        - mv ./tmp/* ./doc/_static/cache
+        - git add ./doc/_static/cache
+        - git commit -m "adding cached badge of $BADGE"
+        - git push -f -q "https://pyviz-developers:$GITHUB_TOKEN@github.com/pyviz/website.git" HEAD:cache
+
+    - <<: *build_cache
+      env: BADGE=stars
+
+    - <<: *build_cache
+      env: BADGE=contributors
+
+    - <<: *build_cache
+      env: BADGE=license
+
+    - <<: *build_cache
+      env: BADGE=conda_downloads
+      script: python tools/conda_downloads.py
+
     - &website_release
       <<: *test
       stage: website_release
-      env: BUILD_CACHE=True
-      script:
-        # these steps can be called using doit build_cache
-        # but the Travis job will time out, so they are split up here
-        - python tools/conda_downloads.py
-        - SECTION="Core" python tools/build_cache.py
-        - SECTION="High-Level Shared API" python tools/build_cache.py
-        - SECTION="High-Level" python tools/build_cache.py
-        - SECTION="Native-GUI" python tools/build_cache.py
-        - SECTION="Other InfoVis" python tools/build_cache.py
-        - SECTION="SciVis" python tools/build_cache.py
-        - SECTION="Geospatial" python tools/build_cache.py
-        - SECTION="Other domain-specific" python tools/build_cache.py
-        - SECTION="Large-data rendering" python tools/build_cache.py
-        - SECTION="Dashboarding" python tools/build_cache.py
-        - SECTION="Colormapping" python tools/build_cache.py
-        - SECTION="Dormant projects" python tools/build_cache.py
-        - doit build_website
+      script: doit build_website
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Build the website using the custom ``doit`` (similar to `make`) command.
 doit build_website
 ```
 
-**NOTE:** To skip badges caching, set the `--nocache` flag.
+**NOTE:** To build the cached badges use `doit build_cache`.
 
 View the website locally
 

--- a/dodo.py
+++ b/dodo.py
@@ -28,19 +28,11 @@ def task_env_create():
 def task_build_cache():
     """Build cache"""
     return {'actions': [
-         "python tools/conda_downloads.py",
-        'SECTION="Core" python tools/build_cache.py',
-        'SECTION="High-Level Shared API" python tools/build_cache.py',
-        'SECTION="High-Level" python tools/build_cache.py',
-        'SECTION="Native-GUI" python tools/build_cache.py',
-        'SECTION="Other InfoVis" python tools/build_cache.py',
-        'SECTION="SciVis" python tools/build_cache.py',
-        'SECTION="Geospatial" python tools/build_cache.py',
-        'SECTION="Other domain-specific" python tools/build_cache.py',
-        'SECTION="Large-data rendering" python tools/build_cache.py',
-        'SECTION="Dashboarding" python tools/build_cache.py',
-        'SECTION="Colormapping" python tools/build_cache.py',
-        'SECTION="Dormant projects" python tools/build_cache.py',
+        "python tools/conda_downloads.py",
+        "BADGE=stars python tools/build_cache.py",
+        "BADGE=contributors python tools/build_cache.py",
+        "BADGE=license python tools/build_cache.py",
+        "BADGE=pypi_downloads python tools/build_cache.py",
      ]}
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -24,21 +24,31 @@ def task_env_create():
         "conda env update -f environment.yml -n pyviz",
     ]}
 
-cache_param = {
-    'name': 'cache',
-    'long': 'cache',
-    'type': bool,
-    'default': True,
-    'inverse': 'nocache',
-}
+
+def task_build_cache():
+    """Build cache"""
+    return {'actions': [
+         "python tools/conda_downloads.py",
+        'SECTION="Core" python tools/build_cache.py',
+        'SECTION="High-Level Shared API" python tools/build_cache.py',
+        'SECTION="High-Level" python tools/build_cache.py',
+        'SECTION="Native-GUI" python tools/build_cache.py',
+        'SECTION="Other InfoVis" python tools/build_cache.py',
+        'SECTION="SciVis" python tools/build_cache.py',
+        'SECTION="Geospatial" python tools/build_cache.py',
+        'SECTION="Other domain-specific" python tools/build_cache.py',
+        'SECTION="Large-data rendering" python tools/build_cache.py',
+        'SECTION="Dashboarding" python tools/build_cache.py',
+        'SECTION="Colormapping" python tools/build_cache.py',
+        'SECTION="Dormant projects" python tools/build_cache.py',
+     ]}
+
 
 def task_build_website():
     """Build website using nbsite"""
     return {'actions': [
-        "echo building cache: %(cache)s",
-        "python tools/conda_downloads.py",
-        "BUILD_CACHE=%(cache)s python tools/build.py",
+        "python tools/build.py",
         "mv tools/index.rst doc/tools.rst",
         "nbsite generate-rst --org pyviz --project-name pyviz --examples notebooks",  # noqa
         "nbsite build --what=html --output=builtdocs",
-    ], 'params': [cache_param]}
+    ]}

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,7 @@ name: pyviz
 channels:
   - conda-forge
 dependencies:
-  - colorcet
-  - fastparquet
   - flake8
-  - intake
-  - intake-parquet
   - jinja2
   - m2r
   - markdown
@@ -16,5 +12,4 @@ dependencies:
   - pytest
   - pyyaml
   - requests
-  - s3fs
   - tornado<6

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,27 +1,11 @@
 #!/usr/bin/env python
-
 import os
 from jinja2 import Template
 from yaml import safe_load
 from markdown import markdown
-import requests
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-cache_path = os.path.join(here, '..', 'doc', '_static', 'cache')
-build_cache = eval(os.getenv('BUILD_CACHE', 'False'))
-
-cache = {
-    "stars": "https://img.shields.io/github/stars/{repo}.svg?style=social",
-    "contributors": "https://img.shields.io/github/contributors/{repo}.svg?style=social&logo=github",
-    "pypi_downloads": "https://img.shields.io/pypi/dm/{pypi_name}.svg?label=pypi",
-    "license": "https://img.shields.io/pypi/l/{pypi_name}.svg?label",
-}
-
-if build_cache:
-    print('Build cache: True')
-    if not os.path.exists(cache_path):
-        os.mkdir(cache_path)
 
 print("Opening config file")
 with open(os.path.join(here, 'tools.yml')) as f:
@@ -63,14 +47,6 @@ for section in config:
                 package['site_protocol'] = 'https'
             else:
                 package['site_protocol'], package['site'] = package['site'].rstrip('/').split('://')
-
-        if build_cache:
-            print(f"Caching badges for {package.get('pypi_name', '')}")
-            for badge, url in cache.items():
-                rendered_url = url.format(repo=package['repo'], pypi_name=package['pypi_name'])
-                r = requests.get(rendered_url)
-                with open(os.path.join(cache_path, f"{package['name']}_{badge}_badge.svg"), 'wb') as f:
-                    f.write(r.content)
 
 with open(os.path.join(here, 'sponsors.yml')) as f:
     sponsors = safe_load(f)

--- a/tools/build.py
+++ b/tools/build.py
@@ -26,6 +26,7 @@ with open(os.path.join(here, 'tools.yml')) as f:
     config = safe_load(f)
 
 for section in config:
+    print(f"Building {section['name']}")
     if section.get('intro'):
         section['intro'] = markdown(section['intro'])
     for package in section['packages']:
@@ -62,6 +63,7 @@ for section in config:
                 package['site_protocol'], package['site'] = package['site'].rstrip('/').split('://')
 
         if build_cache:
+            print(f"Caching badges for {package['pypi_name']}")
             for badge, url in cache.items():
                 rendered_url = url.format(repo=package['repo'], pypi_name=package['pypi_name'])
                 r = requests.get(rendered_url)

--- a/tools/build.py
+++ b/tools/build.py
@@ -19,14 +19,16 @@ cache = {
 }
 
 if build_cache:
+    print('Build cache: True')
     if not os.path.exists(cache_path):
         os.mkdir(cache_path)
 
+print("Opening config file")
 with open(os.path.join(here, 'tools.yml')) as f:
     config = safe_load(f)
 
 for section in config:
-    print(f"Building {section['name']}")
+    print(f"Building {section.get('name', '')}")
     if section.get('intro'):
         section['intro'] = markdown(section['intro'])
     for package in section['packages']:
@@ -63,7 +65,7 @@ for section in config:
                 package['site_protocol'], package['site'] = package['site'].rstrip('/').split('://')
 
         if build_cache:
-            print(f"Caching badges for {package['pypi_name']}")
+            print(f"Caching badges for {package.get('pypi_name', '')}")
             for badge, url in cache.items():
                 rendered_url = url.format(repo=package['repo'], pypi_name=package['pypi_name'])
                 r = requests.get(rendered_url)

--- a/tools/build_cache.py
+++ b/tools/build_cache.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import os
+from yaml import safe_load
+import requests
+
+here = os.path.abspath(os.path.dirname(__file__))
+cache_path = os.path.join(here, '..', 'doc', '_static', 'cache')
+SECTION = os.getenv('SECTION', '')
+
+cache = {
+    "stars": "https://img.shields.io/github/stars/{repo}.svg?style=social",
+    "contributors": "https://img.shields.io/github/contributors/{repo}.svg?style=social&logo=github",
+    "pypi_downloads": "https://img.shields.io/pypi/dm/{pypi_name}.svg?label=pypi",
+    "license": "https://img.shields.io/pypi/l/{pypi_name}.svg?label",
+}
+
+if not os.path.exists(cache_path):
+    os.mkdir(cache_path)
+
+with open(os.path.join(here, 'tools.yml')) as f:
+    config = safe_load(f)
+
+sections = [section for section in config if section['name'] == SECTION]
+if len(sections) == 0:
+    raise ValueError('Define a valid section. One of: {}'.format(
+        ', '.join([section['name'] for section in config])))
+section = sections[0]
+
+print(f"Building cache for {section.get('name', '')}")
+for package in section['packages']:
+    try:
+        package['user'], package['name'] = package['repo'].split('/')
+    except:
+        raise Warning('Package.repo is not in correct format', package)
+        continue
+    package['pypi_name'] = package.get('pypi_name', package['name'])
+
+    print(f"  * package: {package.get('pypi_name', '')}")
+    for badge, url in cache.items():
+        rendered_url = url.format(repo=package['repo'], pypi_name=package['pypi_name'])
+        r = requests.get(rendered_url)
+        with open(os.path.join(cache_path, f"{package['name']}_{badge}_badge.svg"), 'wb') as f:
+            f.write(r.content)

--- a/tools/build_cache.py
+++ b/tools/build_cache.py
@@ -6,7 +6,7 @@ import requests
 
 here = os.path.abspath(os.path.dirname(__file__))
 cache_path = os.path.join(here, '..', 'doc', '_static', 'cache')
-SECTION = os.getenv('SECTION', '')
+badge = os.getenv('BADGE')
 
 cache = {
     "stars": "https://img.shields.io/github/stars/{repo}.svg?style=social",
@@ -14,6 +14,10 @@ cache = {
     "pypi_downloads": "https://img.shields.io/pypi/dm/{pypi_name}.svg?label=pypi",
     "license": "https://img.shields.io/pypi/l/{pypi_name}.svg?label",
 }
+url = cache.get(badge)
+if url is None:
+    raise ValueError((f'{badge} not in {", ".join(cache.keys())}, use env '
+                      'var BADGE to set.'))
 
 if not os.path.exists(cache_path):
     os.mkdir(cache_path)
@@ -21,23 +25,17 @@ if not os.path.exists(cache_path):
 with open(os.path.join(here, 'tools.yml')) as f:
     config = safe_load(f)
 
-sections = [section for section in config if section['name'] == SECTION]
-if len(sections) == 0:
-    raise ValueError('Define a valid section. One of: {}'.format(
-        ', '.join([section['name'] for section in config])))
-section = sections[0]
+for section in config:
+    print(f"Building cache for {section.get('name', '')}")
+    for package in section['packages']:
+        try:
+            package['user'], package['name'] = package['repo'].split('/')
+        except:
+            raise Warning('Package.repo is not in correct format', package)
+            continue
+        package['pypi_name'] = package.get('pypi_name', package['name'])
 
-print(f"Building cache for {section.get('name', '')}")
-for package in section['packages']:
-    try:
-        package['user'], package['name'] = package['repo'].split('/')
-    except:
-        raise Warning('Package.repo is not in correct format', package)
-        continue
-    package['pypi_name'] = package.get('pypi_name', package['name'])
-
-    print(f"  * package: {package.get('pypi_name', '')}")
-    for badge, url in cache.items():
+        print(f"  * package: {package.get('pypi_name', '')}")
         rendered_url = url.format(repo=package['repo'], pypi_name=package['pypi_name'])
         r = requests.get(rendered_url)
         with open(os.path.join(cache_path, f"{package['name']}_{badge}_badge.svg"), 'wb') as f:


### PR DESCRIPTION
This PR splits the badge caching up and stores the cached output so that if one of the badge sites is unresponsive (like pypistats.org is at the moment), the rest of the site can still be built.