### PR TITLE
Update itkwidgets repo name [build:website_dev]

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -160,7 +160,7 @@
     - repo: glumpy/glumpy
       badges: pypi, rtd
 
-    - repo: InsightSoftwareConsortium/itk-jupyter-widgets
+    - repo: InsightSoftwareConsortium/itkwidgets
       pypi_name: itkwidgets
       conda_package: itkwidgets
       conda_channel: conda-forge


### PR DESCRIPTION
The repository was re-named from "itk-jupyter-widgets" to "itkwidgets"